### PR TITLE
Wrong time generated in reports

### DIFF
--- a/src/Test/Infra/QualityVault/QualityVaultUtilities/Reporting/XUnitReportGenerator.cs
+++ b/src/Test/Infra/QualityVault/QualityVaultUtilities/Reporting/XUnitReportGenerator.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Test.Reporting
                 var assembly = new XElement("assembly");
                 assembly.SetAttributeValue("name", assemblyName);
                 assembly.SetAttributeValue("test-framework", "QualityVault");
-                assembly.SetAttributeValue("run-date", DateTime.Now.ToString("yyyy-mm-dd"));
+                assembly.SetAttributeValue("run-date", DateTime.Now.ToString("yyyy-MM-dd"));
                 assembly.SetAttributeValue("run-time", areaEntry.StartTime.ToString(@"hh\:mm\:ss"));
                 assembly.SetAttributeValue("time", (areaEntry.EndTime - areaEntry.StartTime).TotalSeconds);
                 assembly.SetAttributeValue("total", areaEntry.TotalVariations);


### PR DESCRIPTION
Fixes Issue #43 

Master PR <!-- Link to PR if any that fixed this in the master branch. -->

## Description

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->
wrong time generated in report xml due to which test reports weren't getting published.
## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
test reports won't be published.
## Regression
No
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
CI
<!-- What kind of testing has been done with the fix. -->

## Risk
Low
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
