### PR TITLE
Reenabled some common dialog tests

### DIFF
--- a/Microsoft.DotNet.Wpf.Test.sln
+++ b/Microsoft.DotNet.Wpf.Test.sln
@@ -283,6 +283,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XTCs", "src\Test\AppModel\F
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DialogTests", "src\Test\AppModel\FeatureTests\CommonDialogs\DialogTests\DialogTests.csproj", "{4BE5CA7A-06BA-46E6-ADC7-F3BD853E3DBC}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DialogTestsPart1", "src\Test\AppModel\FeatureTests\CommonDialogs\Part1\DialogTests\DialogTestsPart1.csproj", "{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DialogResultConverter", "src\Test\AppModel\FeatureTests\CommonDialogs\DialogResultConverter\DialogResultConverter.csproj", "{0396E9D1-C030-41DC-B0D2-5856853449B4}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Security", "src\Test\AppModel\FeatureTests\Security\ClrUnmanagedCodeCheck\Security.csproj", "{B421E9B9-F04D-4583-A0E9-C27C88ABDFD7}"
@@ -4245,6 +4247,18 @@ Global
 		{4BE5CA7A-06BA-46E6-ADC7-F3BD853E3DBC}.Release|x64.Build.0 = Release|x64
 		{4BE5CA7A-06BA-46E6-ADC7-F3BD853E3DBC}.Release|x86.ActiveCfg = Release|Any CPU
 		{4BE5CA7A-06BA-46E6-ADC7-F3BD853E3DBC}.Release|x86.Build.0 = Release|Any CPU
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Debug|x64.ActiveCfg = Debug|x64
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Debug|x64.Build.0 = Debug|x64
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Debug|x86.Build.0 = Debug|Any CPU
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Release|x64.ActiveCfg = Release|x64
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Release|x64.Build.0 = Release|x64
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Release|x86.ActiveCfg = Release|Any CPU
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Release|x86.Build.0 = Release|Any CPU
 		{A529095D-FC33-4B49-9E19-91A90B694C06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A529095D-FC33-4B49-9E19-91A90B694C06}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A529095D-FC33-4B49-9E19-91A90B694C06}.Debug|x64.ActiveCfg = Debug|x64

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/Part1/DialogTests/DialogTestsPart1.csproj
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/Part1/DialogTests/DialogTestsPart1.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <RootNamespace>Microsoft.Test.WPF.AppModel.CommonDialogs</RootNamespace>
-    <AssemblyName>DialogTests</AssemblyName>
-    <PublishDir>$(PublishDir)\DialogTests</PublishDir>
+    <AssemblyName>DialogTestsPart1</AssemblyName>
+    <PublishDir>$(PublishDir)\DialogTestsPart1</PublishDir>
     <OutputType>winexe</OutputType>
     <Configuration>Release</Configuration>
   </PropertyGroup>

--- a/src/Test/AppModel/FeatureTests/XTCs/CommonDialogs.xtc
+++ b/src/Test/AppModel/FeatureTests/XTCs/CommonDialogs.xtc
@@ -525,7 +525,7 @@
    </Versions>
 </TEST>
 
-<!--<TEST Name="CommonDialog_CustomPlaceCases"
+<TEST Name="CommonDialog_CustomPlaceCases"
       Priority="1"
       Type="Functional"
       Area="AppModel"
@@ -536,17 +536,17 @@
                  Assembly="TestRuntime"
                  Method="RunApplication"
                  SecurityLevel="FullTrust"
-                 MethodParams="DialogTests.exe /test:customplacecases" />
+                 MethodParams="DialogTestsPart1.exe /test:customplacecases" />
    <SupportFiles>
-      <SupportFile Source="FeatureTests\AppModel\DialogTests\*" />
+      <SupportFile Source="FeatureTests\AppModel\DialogTestsPart1\*" />
    </SupportFiles>
    <Versions>
       <Version>4.0+</Version>
       <Version>4.0Client+</Version>
    </Versions>
-</TEST>-->
+</TEST>
 
-<!--<TEST Name="CommonDialog_FileDialogCustomPlaceCases"
+<TEST Name="CommonDialog_FileDialogCustomPlaceCases"
       Priority="1"
       Type="Functional"
       Area="AppModel"
@@ -557,17 +557,17 @@
                  Assembly="TestRuntime"
                  Method="RunApplication"
                  SecurityLevel="FullTrust"
-                 MethodParams="DialogTests.exe /test:filedialogcustomplacecases" />
+                 MethodParams="DialogTestsPart1.exe /test:filedialogcustomplacecases" />
    <SupportFiles>
-      <SupportFile Source="FeatureTests\AppModel\DialogTests\*" />
+      <SupportFile Source="FeatureTests\AppModel\DialogTestsPart1\*" />
    </SupportFiles>
    <Versions>
       <Version>4.0+</Version>
       <Version>4.0Client+</Version>
    </Versions>
-</TEST>-->
+</TEST>
 
-<!--<TEST Name="CommonDialog_OpenFileBeforeShow"
+<TEST Name="CommonDialog_OpenFileBeforeShow"
       Priority="1"
       Type="Functional"
       Area="AppModel"
@@ -578,17 +578,17 @@
                  Assembly="TestRuntime"
                  Method="RunApplication"
                  SecurityLevel="FullTrust"
-                 MethodParams="DialogTests.exe /test:openfilebeforeshow" />
+                 MethodParams="DialogTestsPart1.exe /test:openfilebeforeshow" />
    <SupportFiles>
-      <SupportFile Source="FeatureTests\AppModel\DialogTests\*" />
+      <SupportFile Source="FeatureTests\AppModel\DialogTestsPart1\*" />
    </SupportFiles>
    <Versions>
       <Version>4.0+</Version>
       <Version>4.0Client+</Version>
    </Versions>
-</TEST>-->
+</TEST>
 
-<!--<TEST Name="CommonDialog_OpenFileIsThreadModal"
+<TEST Name="CommonDialog_OpenFileIsThreadModal"
       Priority="1"
       Type="Functional"
       Area="AppModel"
@@ -599,17 +599,17 @@
                  Assembly="TestRuntime"
                  Method="RunApplication"
                  SecurityLevel="FullTrust"
-                 MethodParams="DialogTests.exe /test:openfileisthreadmodal" />
+                 MethodParams="DialogTestsPart1.exe /test:openfileisthreadmodal" />
    <SupportFiles>
-      <SupportFile Source="FeatureTests\AppModel\DialogTests\*" />
+      <SupportFile Source="FeatureTests\AppModel\DialogTestsPart1\*" />
    </SupportFiles>
    <Versions>
       <Version>4.0+</Version>
       <Version>4.0Client+</Version>
    </Versions>
-</TEST>-->
+</TEST>
 
-<!--<TEST Name="CommonDialog_SaveFileIsThreadModal"
+<TEST Name="CommonDialog_SaveFileIsThreadModal"
       Priority="1"
       Type="Functional"
       Area="AppModel"
@@ -620,17 +620,17 @@
                  Assembly="TestRuntime"
                  Method="RunApplication"
                  SecurityLevel="FullTrust"
-                 MethodParams="DialogTests.exe /test:savefileisthreadmodal" />
+                 MethodParams="DialogTestsPart1.exe /test:savefileisthreadmodal" />
    <SupportFiles>
-      <SupportFile Source="FeatureTests\AppModel\DialogTests\*" />
+      <SupportFile Source="FeatureTests\AppModel\DialogTestsPart1\*" />
    </SupportFiles>
    <Versions>
       <Version>4.0+</Version>
       <Version>4.0Client+</Version>
    </Versions>
-</TEST>-->
+</TEST>
 
-<!--<TEST Name="CommonDialog_OpenFileOnSecondThread"
+<TEST Name="CommonDialog_OpenFileOnSecondThread"
       Priority="1"
       Type="Functional"
       Area="AppModel"
@@ -642,17 +642,17 @@
                  Assembly="TestRuntime"
                  Method="RunApplication"
                  SecurityLevel="FullTrust"
-                 MethodParams="DialogTests.exe /test:openfileonsecondthread" />
+                 MethodParams="DialogTestsPart1.exe /test:openfileonsecondthread" />
    <SupportFiles>
-      <SupportFile Source="FeatureTests\AppModel\DialogTests\*" />
+      <SupportFile Source="FeatureTests\AppModel\DialogTestsPart1\*" />
    </SupportFiles>
    <Versions>
       <Version>4.0+</Version>
       <Version>4.0Client+</Version>
    </Versions>
-</TEST>-->
+</TEST>
 
-<!--<TEST Name="CommonDialog_SaveFileOnSecondThread"
+<TEST Name="CommonDialog_SaveFileOnSecondThread"
       Priority="1"
       Type="Functional"
       Area="AppModel"
@@ -664,15 +664,15 @@
                  Assembly="TestRuntime"
                  Method="RunApplication"
                  SecurityLevel="FullTrust"
-                 MethodParams="DialogTests.exe /test:savefileonsecondthread" />
+                 MethodParams="DialogTestsPart1.exe /test:savefileonsecondthread" />
    <SupportFiles>
-      <SupportFile Source="FeatureTests\AppModel\DialogTests\*" />
+      <SupportFile Source="FeatureTests\AppModel\DialogTestsPart1\*" />
    </SupportFiles>
    <Versions>
       <Version>4.0+</Version>
       <Version>4.0Client+</Version>
    </Versions>
-</TEST>-->
+</TEST>
 
 </XTC>
 


### PR DESCRIPTION
Fixes Issue <!-- Issue Number --> #115 partially

## Description
Re-enables some CommonDialog tests.
The issue was that the project files and test collection files did not have the right settings / configurations.
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Developers will be able to tests CommonDialog ( including file dialog ) changes.
<!-- What is the impact to customers of not taking this fix? -->

## Regression
--
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Built and ran the tests
<!-- What kind of testing has been done with the fix. -->

## Risk
--
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf-test/pull/126)