### PR TITLE
Added few tests for OpenFolderDialog

### DIFF
--- a/Microsoft.DotNet.Wpf.Test.sln
+++ b/Microsoft.DotNet.Wpf.Test.sln
@@ -285,10 +285,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DialogTests", "src\Test\App
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DialogTestsPart1", "src\Test\AppModel\FeatureTests\CommonDialogs\Part1\DialogTests\DialogTestsPart1.csproj", "{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FolderDialogTests", "src\Test\AppModel\FeatureTests\CommonDialogs\OpenFolderDialogTests\FolderDialogTests\FolderDialogTests.csproj", "{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenFolderDialogTests", "src\Test\AppModel\FeatureTests\CommonDialogs\OpenFolderDialogTests\OpenFolderDialogTests.csproj", "{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DialogResultConverter", "src\Test\AppModel\FeatureTests\CommonDialogs\DialogResultConverter\DialogResultConverter.csproj", "{0396E9D1-C030-41DC-B0D2-5856853449B4}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Security", "src\Test\AppModel\FeatureTests\Security\ClrUnmanagedCodeCheck\Security.csproj", "{B421E9B9-F04D-4583-A0E9-C27C88ABDFD7}"

--- a/Microsoft.DotNet.Wpf.Test.sln
+++ b/Microsoft.DotNet.Wpf.Test.sln
@@ -285,6 +285,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DialogTests", "src\Test\App
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DialogTestsPart1", "src\Test\AppModel\FeatureTests\CommonDialogs\Part1\DialogTests\DialogTestsPart1.csproj", "{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FolderDialogTests", "src\Test\AppModel\FeatureTests\CommonDialogs\OpenFolderDialogTests\FolderDialogTests\FolderDialogTests.csproj", "{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenFolderDialogTests", "src\Test\AppModel\FeatureTests\CommonDialogs\OpenFolderDialogTests\OpenFolderDialogTests.csproj", "{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DialogResultConverter", "src\Test\AppModel\FeatureTests\CommonDialogs\DialogResultConverter\DialogResultConverter.csproj", "{0396E9D1-C030-41DC-B0D2-5856853449B4}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Security", "src\Test\AppModel\FeatureTests\Security\ClrUnmanagedCodeCheck\Security.csproj", "{B421E9B9-F04D-4583-A0E9-C27C88ABDFD7}"
@@ -4259,6 +4263,30 @@ Global
 		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Release|x64.Build.0 = Release|x64
 		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Release|x86.ActiveCfg = Release|Any CPU
 		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Release|x86.Build.0 = Release|Any CPU
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Debug|x64.ActiveCfg = Debug|x64
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Debug|x64.Build.0 = Debug|x64
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Debug|x86.Build.0 = Debug|Any CPU
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Release|x64.ActiveCfg = Release|x64
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Release|x64.Build.0 = Release|x64
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Release|x86.ActiveCfg = Release|Any CPU
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Release|x86.Build.0 = Release|Any CPU
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Debug|x64.ActiveCfg = Debug|x64
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Debug|x64.Build.0 = Debug|x64
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Debug|x86.Build.0 = Debug|Any CPU
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Release|x64.ActiveCfg = Release|x64
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Release|x64.Build.0 = Release|x64
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Release|x86.ActiveCfg = Release|Any CPU
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Release|x86.Build.0 = Release|Any CPU
 		{A529095D-FC33-4B49-9E19-91A90B694C06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A529095D-FC33-4B49-9E19-91A90B694C06}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A529095D-FC33-4B49-9E19-91A90B694C06}.Debug|x64.ActiveCfg = Debug|x64

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -5,7 +5,7 @@ Param(
   [string] $projects,
   [string][Alias('v')]$verbosity = "minimal",
   [string] $msbuildEngine = $null,
-  [bool] $warnAsError = $true,
+  [bool] $warnAsError = $false,
   [bool] $nodeReuse = $true,
   [switch][Alias('r')]$restore,
   [switch] $deployDeps,

--- a/global.json
+++ b/global.json
@@ -1,20 +1,14 @@
 {
   "tools": {
-    "dotnet": "8.0.100-preview.3.23178.7",
-    "runtimes": {
-      "dotnet": [
-        "2.1.7",
-        "$(MicrosoftNETCoreAppVersion)"
-      ]
-    },
+    "dotnet": "8.0.100-preview.2.23157.25",
     "vs": {
       "version": "16.11"
     }
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23224.5",
-    "Microsoft.DotNet.Arcade.Wpf.Sdk": "6.0.0-alpha.1.21071.6",
-    "Microsoft.NET.Sdk.WindowsDesktop": "6.0.0-preview.6.21276.7"
+    "Microsoft.DotNet.Arcade.Wpf.Sdk": "7.0.0-alpha.1.21611.1",
+    "Microsoft.NET.Sdk.WindowsDesktop": "7.0.0-alpha.1.21560.1"
   },
   "native-tools": {
     "strawberry-perl": "5.28.1.1-1",

--- a/global.json
+++ b/global.json
@@ -1,14 +1,20 @@
 {
   "tools": {
-    "dotnet": "8.0.100-preview.2.23157.25",
+    "dotnet": "8.0.100-preview.3.23178.7",
+    "runtimes": {
+      "dotnet": [
+        "2.1.7",
+        "$(MicrosoftNETCoreAppVersion)"
+      ]
+    },
     "vs": {
       "version": "16.11"
     }
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23224.5",
-    "Microsoft.DotNet.Arcade.Wpf.Sdk": "7.0.0-alpha.1.21611.1",
-    "Microsoft.NET.Sdk.WindowsDesktop": "7.0.0-alpha.1.21560.1"
+    "Microsoft.DotNet.Arcade.Wpf.Sdk": "6.0.0-alpha.1.21071.6",
+    "Microsoft.NET.Sdk.WindowsDesktop": "6.0.0-preview.6.21276.7"
   },
   "native-tools": {
     "strawberry-perl": "5.28.1.1-1",

--- a/src/Test/AppModel/AppModel.sln
+++ b/src/Test/AppModel/AppModel.sln
@@ -15,10 +15,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InternalUtilities", "..\Inf
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrtAppModelSuites", "DRT\AppModelSuites\DrtAppModelSuites.csproj", "{A96B02D1-32AD-4484-B94F-B8FED2775C2C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrtThirdPartyThemes", "DRT\NewLoaderSuiteHelperProject1\DrtThirdPartyThemes.csproj", "{37C4B595-5FD2-48A7-A22C-61C82F98FC43}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrtThirdPartyThemes2", "DRT\NewLoaderSuiteHelperProject2\DrtThirdPartyThemes2.csproj", "{670C0D0D-E653-4B0D-9B70-017D758B97BC}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrtApplicationEvents", "DRT\Application\ApplicationEvents\DrtApplicationEvents.csproj", "{9CA98BFB-FFD3-4E92-A866-078A0AB530D3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrtAppShutdown", "DRT\Application\AppShutdown\DrtAppShutdown.csproj", "{60236464-3181-4E68-8409-674445DD2477}"
@@ -49,8 +45,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrtNavigationToObject", "DR
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrtNavigationWindow", "DRT\Navigation\NavigationWindow\DrtNavigationWindow.csproj", "{9BD16CF7-8129-4047-81A9-EC5E46826D4C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrtNavMemPerf", "DRT\Navigation\NavMemPerf\DrtNavMemPerf.csproj", "{B26B6019-F970-4F26-965E-92FC7D4D28A9}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrtXamlContainer", "DRT\Navigation\XamlContainer\DrtXamlContainer.csproj", "{3BF6F369-5D61-44AF-81C1-DB0770811712}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrtPageFunction", "DRT\PageFunction\DrtPageFunction.csproj", "{D97400A2-A87F-4B07-A522-76415FF76B70}"
@@ -79,7 +73,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrtWindowResizeGripFlowDire
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DrtWindowScroll", "DRT\Window\WindowScroll\DrtWindowScroll.csproj", "{E3D925D1-F37C-49E0-9531-53A37E1C198B}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DialogTests", "FeatureTests\CommonDialogs\Dev10\DialogTests\DialogTests.csproj", "{5DF9E262-F95E-4989-87C6-7FBA1D2E09FA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DialogTests", "FeatureTests\CommonDialogs\DialogTests\DialogTests.csproj", "{4BE5CA7A-06BA-46E6-ADC7-F3BD853E3DBC}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DialogResultConverter", "FeatureTests\CommonDialogs\DialogResultConverter\DialogResultConverter.csproj", "{02BAE7A7-0268-4D3D-9F7C-2E2D9B836647}"
 EndProject
@@ -98,6 +92,14 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AppModelData", "FeatureTests\Data\AppModelData.csproj", "{EF048A00-DF86-4CFC-8036-89B2A59F9660}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CompilationTests", "FeatureTests\Compilation\CompilationTests.csproj", "{F2F065CD-7B6A-4EB7-9711-B50C4CDDFEF8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FolderDialogTests", "FeatureTests\CommonDialogs\OpenFolderDialogTests\FolderDialogTests\FolderDialogTests.csproj", "{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenFolderDialogTests", "FeatureTests\CommonDialogs\OpenFolderDialogTests\OpenFolderDialogTests.csproj", "{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Standalone", "FeatureTests\CommonDialogs\CommonDialogs\standalone\standalone.csproj", "{31ADCF9D-FB24-4A14-9DDD-504DBB3823EA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DialogTestsPart1", "FeatureTests\CommonDialogs\Part1\DialogTests\DialogTestsPart1.csproj", "{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -685,6 +687,67 @@ Global
 		{F2F065CD-7B6A-4EB7-9711-B50C4CDDFEF8}.Release|x64.Build.0 = Release|x64
 		{F2F065CD-7B6A-4EB7-9711-B50C4CDDFEF8}.Release|x86.ActiveCfg = Release|Any CPU
 		{F2F065CD-7B6A-4EB7-9711-B50C4CDDFEF8}.Release|x86.Build.0 = Release|Any CPU
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Debug|x64.ActiveCfg = Debug|x64
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Debug|x64.Build.0 = Debug|x64
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Debug|x86.Build.0 = Debug|Any CPU
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Release|x64.ActiveCfg = Release|x64
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Release|x64.Build.0 = Release|x64
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Release|x86.ActiveCfg = Release|Any CPU
+		{0C7BC4B4-B562-4695-BEE7-44E04FF24BF8}.Release|x86.Build.0 = Release|Any CPU
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Debug|x64.ActiveCfg = Debug|x64
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Debug|x64.Build.0 = Debug|x64
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Debug|x86.Build.0 = Debug|Any CPU
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Release|x64.ActiveCfg = Release|x64
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Release|x64.Build.0 = Release|x64
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Release|x86.ActiveCfg = Release|Any CPU
+		{EEB9D52A-CDE1-4831-9B1E-01DF201037BA}.Release|x86.Build.0 = Release|Any CPU
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Debug|x64.ActiveCfg = Debug|x64
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Debug|x64.Build.0 = Debug|x64
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Debug|x86.Build.0 = Debug|Any CPU
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Release|x64.ActiveCfg = Release|x64
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Release|x64.Build.0 = Release|x64
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Release|x86.ActiveCfg = Release|Any CPU
+		{0BF61BA9-AB8A-41EB-B3C5-F864BA0036D9}.Release|x86.Build.0 = Release|Any CPU
+		{31ADCF9D-FB24-4A14-9DDD-504DBB3823EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{31ADCF9D-FB24-4A14-9DDD-504DBB3823EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{31ADCF9D-FB24-4A14-9DDD-504DBB3823EA}.Debug|x64.ActiveCfg = Debug|x64
+		{31ADCF9D-FB24-4A14-9DDD-504DBB3823EA}.Debug|x64.Build.0 = Debug|x64
+		{31ADCF9D-FB24-4A14-9DDD-504DBB3823EA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{31ADCF9D-FB24-4A14-9DDD-504DBB3823EA}.Debug|x86.Build.0 = Debug|Any CPU
+		{31ADCF9D-FB24-4A14-9DDD-504DBB3823EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{31ADCF9D-FB24-4A14-9DDD-504DBB3823EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{31ADCF9D-FB24-4A14-9DDD-504DBB3823EA}.Release|x64.ActiveCfg = Release|x64
+		{31ADCF9D-FB24-4A14-9DDD-504DBB3823EA}.Release|x64.Build.0 = Release|x64
+		{31ADCF9D-FB24-4A14-9DDD-504DBB3823EA}.Release|x86.ActiveCfg = Release|Any CPU
+		{31ADCF9D-FB24-4A14-9DDD-504DBB3823EA}.Release|x86.Build.0 = Release|Any CPU
+		{4BE5CA7A-06BA-46E6-ADC7-F3BD853E3DBC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4BE5CA7A-06BA-46E6-ADC7-F3BD853E3DBC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4BE5CA7A-06BA-46E6-ADC7-F3BD853E3DBC}.Debug|x64.ActiveCfg = Debug|x64
+		{4BE5CA7A-06BA-46E6-ADC7-F3BD853E3DBC}.Debug|x64.Build.0 = Debug|x64
+		{4BE5CA7A-06BA-46E6-ADC7-F3BD853E3DBC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4BE5CA7A-06BA-46E6-ADC7-F3BD853E3DBC}.Debug|x86.Build.0 = Debug|Any CPU
+		{4BE5CA7A-06BA-46E6-ADC7-F3BD853E3DBC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4BE5CA7A-06BA-46E6-ADC7-F3BD853E3DBC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4BE5CA7A-06BA-46E6-ADC7-F3BD853E3DBC}.Release|x64.ActiveCfg = Release|x64
+		{4BE5CA7A-06BA-46E6-ADC7-F3BD853E3DBC}.Release|x64.Build.0 = Release|x64
+		{4BE5CA7A-06BA-46E6-ADC7-F3BD853E3DBC}.Release|x86.ActiveCfg = Release|Any CPU
+		{4BE5CA7A-06BA-46E6-ADC7-F3BD853E3DBC}.Release|x86.Build.0 = Release|Any CPU
+
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/FolderDialogTests/FolderDialogCustomPlaceCases.cs
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/FolderDialogTests/FolderDialogCustomPlaceCases.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections;
+using System.IO;
+using System.Windows;
+using Microsoft.Win32;
+using Microsoft.Test.Logging;
+
+namespace Microsoft.Test.WPF.AppModel.CommonDialogs
+{
+    public class FolderDialogCustomPlaceCases : Application
+    {
+        public FolderDialogCustomPlaceCases()
+        {
+        }
+
+        protected override void OnStartup (StartupEventArgs e)
+        {
+            FileDialogCustomPlace customPlace = null;
+            try
+            {
+                //Case 1: Verify we can get back the file Path after setting it
+                customPlace = new FileDialogCustomPlace("c:\\bogus");
+                if (customPlace.Path == "c:\\bogus")
+                {
+                    Logging.SetPass("FileDialogCustomPlace was c:\\bogus, as expected.");
+                }
+                else
+                {
+                    Logging.SetFail("FileDialogCustomPlace was not c:\\bogus, as expected.  Instead it was: " + customPlace.Path);
+                }
+
+                //Case 2: Verify FileDialogCustomPlace created with string returns empty Guid
+                if (customPlace.KnownFolder == Guid.Empty)
+                {
+                    Logging.SetPass("FileDialogCustomPlace.KnownFolder was Guid.Empty, as expected.");
+                }
+                else
+                {
+                    Logging.SetFail("FileDialogCustomPlace was not Guid.Empty, as expected.  Instead it was: " + customPlace.KnownFolder.ToString());
+                }
+
+                //Case 3: Verify we can get back the Guid after setting it
+                customPlace = FileDialogCustomPlaces.Documents;
+                if (customPlace.KnownFolder == new Guid("FDD39AD0-238F-46AF-ADB4-6C85480369C7"))
+                {
+                    Logging.SetPass("FileDialogCustomPlace.KnownFolder was FileDialogCustomPlaces.Documents, as expected.");
+                }
+                else
+                {
+                    Logging.SetFail("FileDialogCustomPlace.KnownFolder was not FileDialogCustomPlaces.Documents, as expected.  Instead it was: " + customPlace.KnownFolder.ToString());
+                }
+
+                //Case 4: Verify FileDialogCustomPlace created with Guid returns null string
+                customPlace = FileDialogCustomPlaces.Documents;
+                if (customPlace.Path == null)
+                {
+                    Logging.SetPass("FileDialogCustomPlace.Path was null, as expected.");
+                }
+                else
+                {
+                    Logging.SetFail("FileDialogCustomPlace.Path was not null, as expected.  Instead it was: " + customPlace.Path);
+                }
+
+                //Case 5: FileDialogCustomPlace.ToString()
+                string customPlaceString = null;
+                customPlaceString = customPlace.ToString();
+                if (customPlaceString != null)
+                {
+                    Logging.SetPass("FileDialogCustomPlace.ToString() was non-null, as expected: " + customPlaceString);
+                }
+                else
+                {
+                    Logging.SetFail("FileDialogCustomPlace.ToString() unexpectedly returned null");
+                }
+
+                //Case 6: Instantiate all FileDialogCustomPlaces.
+                OpenFolderDialog openDialog = new OpenFolderDialog();
+                openDialog.CustomPlaces.Add(FileDialogCustomPlaces.Contacts);
+                openDialog.CustomPlaces.Add(FileDialogCustomPlaces.RoamingApplicationData);
+                openDialog.CustomPlaces.Add(FileDialogCustomPlaces.LocalApplicationData);
+                openDialog.CustomPlaces.Add(FileDialogCustomPlaces.Cookies);
+                openDialog.CustomPlaces.Add(FileDialogCustomPlaces.Favorites);
+                openDialog.CustomPlaces.Add(FileDialogCustomPlaces.Programs);
+                openDialog.CustomPlaces.Add(FileDialogCustomPlaces.Music);
+                openDialog.CustomPlaces.Add(FileDialogCustomPlaces.Pictures);
+                openDialog.CustomPlaces.Add(FileDialogCustomPlaces.SendTo);
+                openDialog.CustomPlaces.Add(FileDialogCustomPlaces.StartMenu);
+                openDialog.CustomPlaces.Add(FileDialogCustomPlaces.Startup);
+                openDialog.CustomPlaces.Add(FileDialogCustomPlaces.System);
+                openDialog.CustomPlaces.Add(FileDialogCustomPlaces.Templates);
+                openDialog.CustomPlaces.Add(FileDialogCustomPlaces.Desktop);
+                openDialog.CustomPlaces.Add(FileDialogCustomPlaces.Documents);
+                openDialog.CustomPlaces.Add(FileDialogCustomPlaces.ProgramFiles);
+                openDialog.CustomPlaces.Add(FileDialogCustomPlaces.ProgramFilesCommon);
+                if (openDialog.CustomPlaces.Count == 17)
+                {
+                    Logging.LogPass("Every FileDialogCustomPlace was created.");
+                }
+                else
+                {
+                    Logging.LogFail("Count of FileDialogCustomPlaces should have been 17.  Instead it was: " + openDialog.CustomPlaces.Count);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logging.LogFail("Unexpected exception: " + ex.ToString());
+            }
+
+            Shutdown();
+        }
+    }
+}

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/FolderDialogTests/FolderDialogTests.csproj
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/FolderDialogTests/FolderDialogTests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>Microsoft.Test.WPF.AppModel.CommonDialogs</RootNamespace>
+    <AssemblyName>FolderDialogTests</AssemblyName>
+    <PublishDir>$(PublishDir)\FolderDialogTests</PublishDir>
+    <OutputType>winexe</OutputType>
+    <Configuration>Release</Configuration>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="main.cs" />
+    <Compile Include="..\..\DialogTests\baseclasses.cs" />
+    
+    <Compile Include="FolderDialogCustomPlaceCases.cs" />
+    <Compile Include="OpenFolderIsThreadModal.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+        <ProjectReference Include="$(InternalUtilitiesProject)" />
+        <ProjectReference Include="$(TestContractsProject)" />
+        <ProjectReference Include="$(TestRuntimeProject)" />
+  </ItemGroup>
+
+</Project>

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/FolderDialogTests/OpenFolderIsThreadModal.cs
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/FolderDialogTests/OpenFolderIsThreadModal.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections;
+using System.IO;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Threading;
+using Microsoft.Win32;
+using Microsoft.Test.Logging;
+
+namespace Microsoft.Test.WPF.AppModel.CommonDialogs
+{
+    public class OpenFolderIsThreadModal : Application
+    {
+        DispatcherTimer timer = new DispatcherTimer();
+
+        protected override void OnStartup (StartupEventArgs e)
+        {
+            OpenFolderDialog openFolderDialog = new OpenFolderDialog();
+
+            //We need to verify IsThreadModal while the dialog is up.  Use a timer that fires 2 seconds from now.
+            timer.Tick += TimerTick;
+            timer.Interval = new TimeSpan(0, 0, 2);
+            timer.Start();
+
+            Logging.LogStatus("Showing the OpenFolderDialog.");
+            openFolderDialog.ShowDialog();
+        }
+ 
+        private void TimerTick(object sender, EventArgs e)
+        {
+            timer.Stop();
+
+            if (ComponentDispatcher.IsThreadModal)
+            {
+                Logging.LogPass("Calling ComponentDispatcher.IsThreadModal while the openFolderDialog was shown returned true as expected.");
+            }
+            else
+            {
+                Logging.LogFail("Calling ComponentDispatcher.IsThreadModal while the openFolderDialog was shown returned false.  Expected: true");
+            }
+
+            Shutdown();
+        }
+    }
+}

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/FolderDialogVerifyHelper.cs
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/FolderDialogVerifyHelper.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using System.Windows;
+using Microsoft.Test.Loaders;
+using Microsoft.Test.Logging;
+
+namespace Microsoft.Wpf.AppModel.CommonDialogs
+{
+    internal static class FolderDialogVerifyHelper
+    {
+        internal static bool CheckSelectedFolders(string[] fileNames, string[] expectedFileNames)
+        {
+            return true;
+        }
+
+        internal static void CreateTestFoldersStructure(string rootDir)
+        {
+            string testDataDir = Path.Combine(rootDir, "testdata");
+            string[] testDataChildDirs = new string[] {"dir1", ".dir2", "dir3"}; 
+            Directory.CreateDirectory(testDataDir);
+            foreach(string childDir in testDataChildDirs)
+            {
+                string pathName = Path.Combine(testDataDir, childDir);
+                Directory.CreateDirectory(pathName);
+            }
+        }
+    }
+}

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/FolderDialogVerifyHelper.cs
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/FolderDialogVerifyHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Windows;
+using System.Collections.Generic;
 using Microsoft.Test.Loaders;
 using Microsoft.Test.Logging;
 
@@ -10,6 +11,20 @@ namespace Microsoft.Wpf.AppModel.CommonDialogs
     {
         internal static bool CheckSelectedFolders(string[] fileNames, string[] expectedFileNames)
         {
+            int length = fileNames.Length;
+            if(length != expectedFileNames.Length)
+            {
+                return false;
+            }
+
+            for(int i=0;i<length;i++)
+            {
+                if(!string.Equals(fileNames[i], expectedFileNames[i]))
+                {
+                    GlobalLog.LogEvidence(string.Format("FileName : {0} does not match expectedFileName : {1}", fileNames[i], expectedFileNames[i]));
+                    return false;
+                }
+            }
             return true;
         }
 
@@ -23,6 +38,23 @@ namespace Microsoft.Wpf.AppModel.CommonDialogs
                 string pathName = Path.Combine(testDataDir, childDir);
                 Directory.CreateDirectory(pathName);
             }
+        }
+
+        internal static string[] GetFileNamesFromSafeFileNames(string parentDir, string[] safeFileNames)
+        {
+            List<string> fileNames = new List<string>();
+
+            if(safeFileNames is null || safeFileNames.Length == 0)
+            {
+                return fileNames.ToArray();
+            }
+
+            foreach(string safeFileName in safeFileNames)
+            {
+                fileNames.Add(Path.Combine(parentDir, safeFileName));
+            }
+
+            return fileNames.ToArray();
         }
     }
 }

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/OpenFolderDialogAllCustomPlacesTest.xaml
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/OpenFolderDialogAllCustomPlacesTest.xaml
@@ -1,0 +1,14 @@
+<Page
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    x:Class="Microsoft.Wpf.AppModel.CommonDialogs.OpenFolderDialogAllCustomPlacesTest"
+    Background="Lavender" 
+    WindowTitle="FolderDialog Test"
+    Loaded="OnLoadedShowOpenFolderDlg">
+    <!-- Don't put Open/Save in the window title - it can confuse ApplicationMonitor -->
+  
+  <DockPanel>
+    <TextBlock Name="statusText" DockPanel.Dock="Left">OpenFolderDialog Test: if you see me, this page has loaded</TextBlock>
+  </DockPanel>
+ 
+</Page>

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/OpenFolderDialogAllCustomPlacesTest.xaml.cs
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/OpenFolderDialogAllCustomPlacesTest.xaml.cs
@@ -1,0 +1,74 @@
+using Microsoft.Win32;
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Interop;
+using Microsoft.Test.Loaders;
+using Microsoft.Test.Logging;
+
+namespace Microsoft.Wpf.AppModel.CommonDialogs
+{
+    public partial class OpenFolderDialogAllCustomPlacesTest : Page
+    {
+        OpenFolderDialog folderDialog = null;
+
+        bool fileOkHappened = false;
+        
+        private void OnLoadedShowOpenFolderDlg(object sender, RoutedEventArgs e)
+        {     
+            GlobalLog.LogEvidence("Creating new OpenFolderDialog");
+            folderDialog = new OpenFolderDialog();
+            if (folderDialog == null)
+            {
+                statusText.Text = "Could not create a new OpenFolderDialog. Exiting.";
+                Common.ExitWithError(statusText.Text);
+                return;
+            }
+            
+            GlobalLog.LogEvidence("Registering OpenFolderDialog eventhandlers");
+            folderDialog.FileOk += new CancelEventHandler(OnOpenFolderDialogOk);
+            
+            // Set starting dir to current directory so that previous tests do not
+            // affect the starting location of the OpenFolderDialog
+            folderDialog.InitialDirectory = Directory.GetCurrentDirectory();
+
+            //Add all available CustomPlaces.  On Vista these will be shown.  On XP they won't be.  But it's valid to add them.
+            folderDialog.CustomPlaces.Add(FileDialogCustomPlaces.Contacts);
+            folderDialog.CustomPlaces.Add(FileDialogCustomPlaces.RoamingApplicationData);
+            folderDialog.CustomPlaces.Add(FileDialogCustomPlaces.LocalApplicationData);
+            folderDialog.CustomPlaces.Add(FileDialogCustomPlaces.Cookies);
+            folderDialog.CustomPlaces.Add(FileDialogCustomPlaces.Favorites);
+            folderDialog.CustomPlaces.Add(FileDialogCustomPlaces.Programs);
+            folderDialog.CustomPlaces.Add(FileDialogCustomPlaces.Music);
+            folderDialog.CustomPlaces.Add(FileDialogCustomPlaces.Pictures);
+            folderDialog.CustomPlaces.Add(FileDialogCustomPlaces.SendTo);
+            folderDialog.CustomPlaces.Add(FileDialogCustomPlaces.StartMenu);
+            folderDialog.CustomPlaces.Add(FileDialogCustomPlaces.Startup);
+            folderDialog.CustomPlaces.Add(FileDialogCustomPlaces.System);
+            folderDialog.CustomPlaces.Add(FileDialogCustomPlaces.Templates);
+            folderDialog.CustomPlaces.Add(FileDialogCustomPlaces.Desktop);
+            folderDialog.CustomPlaces.Add(FileDialogCustomPlaces.Documents);
+            folderDialog.CustomPlaces.Add(FileDialogCustomPlaces.ProgramFiles);
+            folderDialog.CustomPlaces.Add(FileDialogCustomPlaces.ProgramFilesCommon);
+
+            GlobalLog.LogEvidence("Displaying OpenFolderDialog with ShowDialog()");
+            folderDialog.ShowDialog(); 
+
+            if (!fileOkHappened) // this is the expected case where we canceled the dialog instead of OK'ing it.
+            {
+                GlobalLog.LogEvidence("As expected, dialog was closed without using OK button.");
+                Common.ExitWithPass();
+            }
+        }
+        
+        private void OnOpenFolderDialogOk(object sender, CancelEventArgs e)
+        {
+            fileOkHappened = true;       
+            statusText.Text = "Not expected: dialog was closed using OK button instead of Cancel.";     
+            Common.ExitWithError(statusText.Text);
+        } 
+    }
+}
+

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/OpenFolderDialogCancelTest.xaml
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/OpenFolderDialogCancelTest.xaml
@@ -1,0 +1,14 @@
+<Page
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    x:Class="Microsoft.Wpf.AppModel.CommonDialogs.OpenFolderDialogCancelTest"
+    Background="Lavender" 
+    WindowTitle="FolderDialog Cancel Test"
+    Loaded="OnLoadedShowOpenFolderDlg">
+    <!-- Don't put Open/Save in the window title - it can confuse ApplicationMonitor -->
+  
+  <DockPanel>
+    <TextBlock Name="statusText" DockPanel.Dock="Left">OpenFolderDialog Cancel Test: if you see me, this page has loaded</TextBlock>
+  </DockPanel>
+ 
+</Page>

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/OpenFolderDialogCancelTest.xaml.cs
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/OpenFolderDialogCancelTest.xaml.cs
@@ -1,0 +1,55 @@
+using Microsoft.Win32;
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Controls;
+using Microsoft.Test.Loaders;
+using Microsoft.Test.Logging;
+
+
+namespace Microsoft.Wpf.AppModel.CommonDialogs
+{
+    public partial class OpenFolderDialogCancelTest : Page
+    {
+        OpenFolderDialog ofd = null;
+        bool fileOkHappened = false;
+        
+        private void OnLoadedShowOpenFolderDlg(object sender, RoutedEventArgs e)
+        {
+            GlobalLog.LogEvidence("Creating new OpenFolderDialog");
+            ofd = new OpenFolderDialog();
+            if (ofd == null)
+            {
+                statusText.Text = "Could not create a new OpenFolderDialog. Exiting.";
+                Common.ExitWithError(statusText.Text);
+                return;
+            }
+            
+            GlobalLog.LogEvidence("Registering OpenFolderDialog eventhandlers");
+            ofd.FileOk += new CancelEventHandler(OnOpenFolderDialogOk);
+            
+            // Set starting dir to current directory so that previous tests do not
+            // affect the starting location of the OpenFolderDialog
+            ofd.InitialDirectory = Directory.GetCurrentDirectory();
+
+            GlobalLog.LogEvidence("Displaying OpenFolderDialog with ShowDialog()");
+            ofd.ShowDialog(); 
+
+            if (!fileOkHappened) // this is the case where we canceled the dialog instead of OK'ing it.
+            {
+                GlobalLog.LogEvidence("Dialog was closed without using OK button.");
+                Common.ExitWithPass();
+            }
+        }
+        
+        private void OnOpenFolderDialogOk(object sender, CancelEventArgs e)
+        {
+            fileOkHappened = true;       
+            statusText.Text = "Dialog was closed using OK button instead of Cancel.";     
+            Common.ExitWithError(statusText.Text);
+        }
+    }
+}
+

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/OpenFolderDialogCustomPlaceTest.xaml
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/OpenFolderDialogCustomPlaceTest.xaml
@@ -1,0 +1,14 @@
+<Page
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    x:Class="Microsoft.Wpf.AppModel.CommonDialogs.OpenFolderDialogCustomPlaceTest"
+    Background="Lavender" 
+    WindowTitle="FolderDialog Test"
+    Loaded="OnLoadedShowOpenFolderDlg">
+    <!-- Don't put Open/Save in the window title - it can confuse ApplicationMonitor -->
+  
+  <DockPanel>
+    <TextBlock Name="statusText" DockPanel.Dock="Left">OpenFolderDialog Test: if you see me, this page has loaded</TextBlock>
+  </DockPanel>
+ 
+</Page>

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/OpenFolderDialogCustomPlaceTest.xaml.cs
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/OpenFolderDialogCustomPlaceTest.xaml.cs
@@ -1,0 +1,68 @@
+using Microsoft.Win32;
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Interop;
+using Microsoft.Test.Loaders;
+using Microsoft.Test.Logging;
+
+
+namespace Microsoft.Wpf.AppModel.CommonDialogs
+{
+    public partial class OpenFolderDialogCustomPlaceTest : Page
+    {
+        OpenFolderDialog folderDialog = null;
+
+        private static string folderName = "testdata";
+        private static string[] expectedFileNames = new string[] {"dir1"};
+
+        private void OnLoadedShowOpenFolderDlg(object sender, RoutedEventArgs e)
+        {     
+            //this test is Vista-only since we actually try to click the CustomPlace.  Just return ignore on non-Vista.
+            if (Environment.OSVersion.Version.Major < 6)
+            { 
+                GlobalLog.LogEvidence("OS is pre-Vista, ignore.");
+                Common.ExitWithIgnore();
+                return;
+            }       
+
+            GlobalLog.LogEvidence("Creating new OpenFolderDialog");
+            folderDialog = new OpenFolderDialog();
+            if (folderDialog == null)
+            {
+                statusText.Text = "Could not create a new OpenFolderDialog. Exiting.";
+                Common.ExitWithError(statusText.Text);
+                return;
+            }
+            
+            GlobalLog.LogEvidence("Registering OpenFolderDialog eventhandlers");
+            folderDialog.FileOk += new CancelEventHandler(OnOpenFolderDialogOk);
+            
+            // Set starting dir to current directory so that previous tests do not
+            // affect the starting location of the OpenFolderDialog
+            folderDialog.InitialDirectory = Directory.GetCurrentDirectory();
+
+            //set testdata as our custom place
+            string pathName = Path.Combine(folderDialog.InitialDirectory, "testdata");
+            folderDialog.CustomPlaces.Add(new FileDialogCustomPlace(pathName));
+
+            GlobalLog.LogEvidence("Displaying OpenFolderDialog with ShowDialog()");
+            folderDialog.ShowDialog(); 
+        }
+        
+        private void OnOpenFolderDialogOk(object sender, CancelEventArgs e)
+        {
+            bool testResult = true; 
+            
+            // [1] check selected Folders
+            testResult = FolderDialogVerifyHelper.CheckSelectedFolders(folderDialog.FileNames, expectedFileNames);
+            if (!testResult)
+            {
+                Common.ExitWithError(statusText.Text);
+            }             
+        }
+    }
+}
+

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/OpenFolderDialogMultiSelect.xaml
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/OpenFolderDialogMultiSelect.xaml
@@ -1,0 +1,14 @@
+<Page
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    x:Class="Microsoft.Wpf.AppModel.CommonDialogs.OpenFolderDialogMultiSelect"
+    Background="Lavender" 
+    WindowTitle="FolderDialog Multiselect Test"
+    Loaded="OnLoadedShowOpenFolderDlg">
+    <!-- Don't put Open/Save in the window title - it can confuse ApplicationMonitor -->
+  
+  <DockPanel>
+    <TextBlock Name="statusText" DockPanel.Dock="Left">OpenFolderDialog Test: if you see me, this page has loaded</TextBlock>
+  </DockPanel>
+ 
+</Page>

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/OpenFolderDialogMultiSelect.xaml.cs
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/OpenFolderDialogMultiSelect.xaml.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Wpf.AppModel.CommonDialogs
         OpenFolderDialog folderDialog = null;
 
         private static string folderName = "testdata";
-        private static string[] expextedFileNames = new string[] {"dir1", "dir3"};
+        private static string[] expectedSafeFileNames = new string[] {"dir1", "dir3"};
         
         private void OnLoadedShowOpenFolderDlg(object sender, RoutedEventArgs e)
         {     
@@ -45,7 +45,7 @@ namespace Microsoft.Wpf.AppModel.CommonDialogs
             
             // Set starting dir to current directory so that previous tests do not
             // affect the starting location of the OpenFolderDialog
-            string initialDirectory = Path.Combine(Directory.GetCurrentDirectory(), "testdata");
+            string initialDirectory = Path.Combine(Directory.GetCurrentDirectory(), folderName);
             folderDialog.InitialDirectory = initialDirectory;
 
             // setting multiselect on dialog
@@ -62,11 +62,24 @@ namespace Microsoft.Wpf.AppModel.CommonDialogs
             // [1] check multiple files are selected
             GlobalLog.LogEvidence("Checking the number of files selected ...");
             testResult = folderDialog.FileNames.Length > 1;
+            
+            if(!testResult)
+            {
+                statusText.Text = "Expected multiple files to be returned. Actual Count :" + folderDialog.FileNames.Length;
+                Common.ExitWithError(statusText.Text);
+            }
 
             // [2] check selected Folders
             GlobalLog.LogEvidence("Checking if the selected folders are the expected ones...");
-            testResult = testResult && FolderDialogVerifyHelper.CheckSelectedFolders(folderDialog.FileNames, expextedFileNames);
-            
+            GlobalLog.LogEvidence("Selected Folders : ");
+            GlobalLog.LogEvidence(string.Join("\n", folderDialog.FileNames));
+
+            string initialDirectory = Path.Combine(Directory.GetCurrentDirectory(), folderName);
+            string[] expectedFileNames = FolderDialogVerifyHelper.GetFileNamesFromSafeFileNames(initialDirectory, expectedSafeFileNames);
+
+            testResult = FolderDialogVerifyHelper.CheckSelectedFolders(folderDialog.FileNames, expectedFileNames);
+            testResult = testResult && FolderDialogVerifyHelper.CheckSelectedFolders(folderDialog.SafeFileNames, expectedSafeFileNames);
+
             if (!testResult)
             {
                 Common.ExitWithError(statusText.Text);

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/OpenFolderDialogMultiSelect.xaml.cs
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/OpenFolderDialogMultiSelect.xaml.cs
@@ -1,0 +1,81 @@
+using Microsoft.Win32;
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Interop;
+using Microsoft.Test.Loaders;
+using Microsoft.Test.Logging;
+
+
+namespace Microsoft.Wpf.AppModel.CommonDialogs
+{
+    public partial class OpenFolderDialogMultiSelect : Page
+    {
+        OpenFolderDialog folderDialog = null;
+
+        private static string folderName = "testdata";
+        private static string[] expextedFileNames = new string[] {"dir1", "dir3"};
+        
+        private void OnLoadedShowOpenFolderDlg(object sender, RoutedEventArgs e)
+        {     
+            GlobalLog.LogEvidence("Creating test data structure for folder dialog tests");
+            FolderDialogVerifyHelper.CreateTestFoldersStructure(Environment.CurrentDirectory);
+
+            //this test is Vista-only since we actually try to click the CustomPlace.  Just return ignore on non-Vista.
+            if (Environment.OSVersion.Version.Major < 6)
+            { 
+                GlobalLog.LogEvidence("OS is pre-Vista, ignore.");
+                Common.ExitWithIgnore();
+                return;
+            }       
+
+            GlobalLog.LogEvidence("Creating new OpenFolderDialog");
+            folderDialog = new OpenFolderDialog();
+            if (folderDialog == null)
+            {
+                statusText.Text = "Could not create a new OpenFolderDialog. Exiting.";
+                Common.ExitWithError(statusText.Text);
+                return;
+            }
+            
+            GlobalLog.LogEvidence("Registering OpenFolderDialog eventhandlers");
+            folderDialog.FileOk += new CancelEventHandler(OnOpenFolderDialogOk);
+            
+            // Set starting dir to current directory so that previous tests do not
+            // affect the starting location of the OpenFolderDialog
+            string initialDirectory = Path.Combine(Directory.GetCurrentDirectory(), "testdata");
+            folderDialog.InitialDirectory = initialDirectory;
+
+            // setting multiselect on dialog
+            folderDialog.Multiselect = true;
+
+            GlobalLog.LogEvidence("Displaying OpenFolderDialog with ShowDialog()");
+            folderDialog.ShowDialog(); 
+        }
+        
+        private void OnOpenFolderDialogOk(object sender, CancelEventArgs e)
+        {
+            bool testResult = true; 
+            
+            // [1] check multiple files are selected
+            GlobalLog.LogEvidence("Checking the number of files selected ...");
+            testResult = folderDialog.FileNames.Length > 1;
+
+            // [2] check selected Folders
+            GlobalLog.LogEvidence("Checking if the selected folders are the expected ones...");
+            testResult = testResult && FolderDialogVerifyHelper.CheckSelectedFolders(folderDialog.FileNames, expextedFileNames);
+            
+            if (!testResult)
+            {
+                Common.ExitWithError(statusText.Text);
+            }
+            else
+            {
+                Common.ExitWithPass();
+            }       
+        }
+    }
+}
+

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/OpenFolderDialogTests.csproj
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/OpenFolderDialogTests.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>Microsoft.Test.WPF.AppModel.CommonDialogs</RootNamespace>
+    <AssemblyName>OpenFolderDialogTests</AssemblyName>
+    <PublishDir>$(PublishDir)\OpenFolderDialogTests</PublishDir>
+    <OutputType>winexe</OutputType>
+    <Configuration>Release</Configuration>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ApplicationDefinition Include="TestAppDef.xaml" />
+    <Compile Include="..\CommonDialogs\Common.cs" />
+    <Compile Include="..\DialogTests\baseclasses.cs" />
+    <Compile Include="TestAppDef.xaml.cs" />
+    <Compile Include="FolderDialogVerifyHelper.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="OpenFolderDialogCustomPlaceTest.xaml.cs" />
+    <Page Include="OpenFolderDialogCustomPlaceTest.xaml" />
+    <Compile Include="OpenFolderDialogAllCustomPlacesTest.xaml.cs" />
+    <Page Include="OpenFolderDialogAllCustomPlacesTest.xaml" />
+    <Compile Include="OpenFolderDialogMultiSelect.xaml.cs" />
+    <Page Include="OpenFolderDialogMultiSelect.xaml" />
+    <Compile Include="OpenFolderDialogCancelTest.xaml.cs" />
+    <Page Include="OpenFolderDialogCancelTest.xaml" />
+  </ItemGroup>
+
+  <!-- <ItemGroup>
+    <Content Include="testdata">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>   -->
+
+  <ItemGroup>
+        <ProjectReference Include="$(InternalUtilitiesProject)" />
+        <ProjectReference Include="$(TestContractsProject)" />
+        <ProjectReference Include="$(TestRuntimeProject)" />
+  </ItemGroup>
+
+</Project>

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/TestAppDef.xaml
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/TestAppDef.xaml
@@ -1,0 +1,5 @@
+<Application
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    x:Class="Microsoft.Wpf.AppModel.CommonDialogs.OpenFolderDialogTests">
+</Application>

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/TestAppDef.xaml.cs
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/TestAppDef.xaml.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Wpf.AppModel.CommonDialogs
         /// [2] grabbing the currentTest type, so we can set the Application StartupUri
         /// [3] grabbing a reference to the Application (so we can later grab a reference to the NavWin)
         /// [4] registering application-level eventhandlers
-        /// [5] creating test data structure
         /// </summary>
         protected override void OnStartup(StartupEventArgs e)
         {

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/TestAppDef.xaml.cs
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/TestAppDef.xaml.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Navigation;
+using Microsoft.Test;
+using Microsoft.Test.Loaders;
+using Microsoft.Test.Logging;
+
+
+namespace Microsoft.Wpf.AppModel.CommonDialogs
+{
+    public partial class OpenFolderDialogTests
+    {
+        private Application       currNavApp      = null;
+        private NavigationWindow  currNavWin      = null;
+        private String            currentTest     = null;
+        private TestLog           log             = null;
+
+        private bool isInitialLoad   = true;
+
+        #region event handlers
+        /// <summary>
+        /// Initializes the test by:
+        /// [1] instantiating the TestLog
+        /// [2] grabbing the currentTest type, so we can set the Application StartupUri
+        /// [3] grabbing a reference to the Application (so we can later grab a reference to the NavWin)
+        /// [4] registering application-level eventhandlers
+        /// [5] creating test data structure
+        /// </summary>
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            log = TestLog.Current == null ? new TestLog("OpenFolderDialog test") : TestLog.Current;
+
+            // Cannot create/grab reference to TestLog.  Exiting test.
+            if (log == null)
+            {
+                ApplicationMonitor.NotifyStopMonitoring();
+            }
+
+            // Grab argument passed into AppMonitor to use as the Application's StartupUri
+            currentTest = DriverState.DriverParameters["TestStartupURI"];
+            if (currentTest == null || currentTest.Equals(String.Empty))
+            {
+                Common.ExitWithError("Usage: need to pass TestStartupURI in the AppMonitor config file for this test");
+            }
+
+            currNavApp = Application.Current;
+            currNavApp.StartupUri = new Uri(currentTest + ".xaml", UriKind.RelativeOrAbsolute);
+
+            // Register the test's eventhandlers
+            log.LogEvidence("Registering LoadCompleted event handler for Application");
+            LoadCompleted += new LoadCompletedEventHandler(OnLoadCompletedAPP);
+        }
+
+
+        /// <summary>
+        /// Further initializes test by:
+        /// [1] Grabbing a reference to the NavigationWindow
+        /// [2] Registering NavigationWindow-level event handlers
+        /// </summary>
+        private void OnLoadCompletedAPP(object sender, NavigationEventArgs e)
+        {
+            if (isInitialLoad)
+            {
+                if (e.Navigator is NavigationWindow)
+                {
+                    log.LogEvidence("Grabbing reference to NavigationWindow.");
+                    currNavWin = currNavApp.MainWindow as NavigationWindow;
+
+                    log.LogEvidence("Registering ContentRendered event handler for NavigationWindow");
+                    currNavWin.ContentRendered += new EventHandler(OnContentRendered_NavWin);
+
+                    isInitialLoad = false;
+                }
+            }
+        }
+
+        private void OnContentRendered_NavWin(object sender, EventArgs e)
+        {
+            log.LogEvidence("CommonFileDialogTest NavigationWindow content rendered.");
+        }
+        #endregion
+    }
+}

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/scripts/OpenFolderDialogAllCustomPlaces_config.xml
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/scripts/OpenFolderDialogAllCustomPlaces_config.xml
@@ -1,0 +1,16 @@
+<AppMonitorConfig>
+  <Using Namespace="Microsoft.Windows.Test.Client.AppSec.BVT" Assembly="CommonFileDialogHandler"/>
+  <Steps>
+    <TestLogStep Name="OpenFolderDialog: AllCustomPlaces - Verify specifying all custom places will still allow the dialog to display">
+      <ActivationStep Method="launch" Scheme="Local" FileName="OpenFolderDialogTests.exe">
+        <ActivationStep.UIHandlers>
+          <CommonFileDialogHandler WindowTitle="property:Microsoft.Test.Loaders.ApplicationDeploymentHelper.OpenFolderDialogTitle, TestRuntime" 
+                             ProcessName="OpenFolderDialogTests" 
+                             Dialog="OpenFolderDialogAllCustomPlaces_config"
+                             FileName="dir1"
+                             TestType="CloseWindowWithXButton"/>
+        </ActivationStep.UIHandlers>
+      </ActivationStep>
+    </TestLogStep>
+  </Steps>
+</AppMonitorConfig>

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/scripts/OpenFolderDialogCancelTest_config.xml
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/scripts/OpenFolderDialogCancelTest_config.xml
@@ -1,7 +1,7 @@
 <AppMonitorConfig>
   <Using Namespace="Microsoft.Windows.Test.Client.AppSec.BVT" Assembly="CommonFileDialogHandler"/>
   <Steps>
-    <TestLogStep Name="OpenFolderDialog: AllCustomPlaces - Verify specifying all custom places will still allow the dialog to display">
+    <TestLogStep Name="OpenFolderDialog: CancelTest - Show open folder dialog, then cancel the dialog without opening">
       <ActivationStep Method="launch" Scheme="Local" FileName="OpenFolderDialogTests.exe">
         <ActivationStep.UIHandlers>
           <CommonFileDialogHandler WindowTitle="property:Microsoft.Test.Loaders.ApplicationDeploymentHelper.OpenFolderDialogTitle, TestRuntime" 

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/scripts/OpenFolderDialogCancelTest_config.xml
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/scripts/OpenFolderDialogCancelTest_config.xml
@@ -1,0 +1,16 @@
+<AppMonitorConfig>
+  <Using Namespace="Microsoft.Windows.Test.Client.AppSec.BVT" Assembly="CommonFileDialogHandler"/>
+  <Steps>
+    <TestLogStep Name="OpenFolderDialog: AllCustomPlaces - Verify specifying all custom places will still allow the dialog to display">
+      <ActivationStep Method="launch" Scheme="Local" FileName="OpenFolderDialogTests.exe">
+        <ActivationStep.UIHandlers>
+          <CommonFileDialogHandler WindowTitle="property:Microsoft.Test.Loaders.ApplicationDeploymentHelper.OpenFolderDialogTitle, TestRuntime" 
+                             ProcessName="OpenFolderDialogTests" 
+                             Dialog="OpenFolderDialogCancelTest"
+                             FileName="dir1"
+                             TestType="TypeFileNameAndCancel"/>
+        </ActivationStep.UIHandlers>
+      </ActivationStep>
+    </TestLogStep>
+  </Steps>
+</AppMonitorConfig>

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/scripts/OpenFolderDialogCustomPlaceTest_config.xml
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/scripts/OpenFolderDialogCustomPlaceTest_config.xml
@@ -1,7 +1,7 @@
 <AppMonitorConfig>
   <Using Namespace="Microsoft.Windows.Test.Client.AppSec.BVT" Assembly="CommonFileDialogHandler"/>
   <Steps>
-    <TestLogStep Name="OpenFolderDialog: AllCustomPlaces - Verify specifying all custom places will still allow the dialog to display">
+    <TestLogStep Name="OpenFolderDialog: CustomPlaces - Verify specifying a custom place, and clicking on it, opens the folder in the custom place">
       <ActivationStep Method="launch" Scheme="Local" FileName="OpenFolderDialogTests.exe">
         <ActivationStep.UIHandlers>
           <CommonFileDialogHandler WindowTitle="property:Microsoft.Test.Loaders.ApplicationDeploymentHelper.OpenFolderDialogTitle, TestRuntime" 

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/scripts/OpenFolderDialogCustomPlaceTest_config.xml
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/scripts/OpenFolderDialogCustomPlaceTest_config.xml
@@ -1,0 +1,16 @@
+<AppMonitorConfig>
+  <Using Namespace="Microsoft.Windows.Test.Client.AppSec.BVT" Assembly="CommonFileDialogHandler"/>
+  <Steps>
+    <TestLogStep Name="OpenFolderDialog: AllCustomPlaces - Verify specifying all custom places will still allow the dialog to display">
+      <ActivationStep Method="launch" Scheme="Local" FileName="OpenFolderDialogTests.exe">
+        <ActivationStep.UIHandlers>
+          <CommonFileDialogHandler WindowTitle="property:Microsoft.Test.Loaders.ApplicationDeploymentHelper.OpenFolderDialogTitle, TestRuntime" 
+                             ProcessName="OpenFolderDialogTests" 
+                             Dialog="OpenFolderDialogCustomPlace"
+                             FileName="dir1"
+                             TestType="VerifyOpenDialogCustomPlace"/>
+        </ActivationStep.UIHandlers>
+      </ActivationStep>
+    </TestLogStep>
+  </Steps>
+</AppMonitorConfig>

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/scripts/OpenFolderDialogMultiSelect_config.xml
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/scripts/OpenFolderDialogMultiSelect_config.xml
@@ -1,0 +1,16 @@
+<AppMonitorConfig>
+  <Using Namespace="Microsoft.Windows.Test.Client.AppSec.BVT" Assembly="CommonFileDialogHandler"/>
+  <Steps>
+    <TestLogStep Name="OpenFolderDialog: AllCustomPlaces - Verify specifying all custom places will still allow the dialog to display">
+      <ActivationStep Method="launch" Scheme="Local" FileName="OpenFolderDialogTests.exe">
+        <ActivationStep.UIHandlers>
+          <CommonFileDialogHandler WindowTitle="property:Microsoft.Test.Loaders.ApplicationDeploymentHelper.OpenFolderDialogTitle, TestRuntime" 
+                             ProcessName="OpenFolderDialogTests" 
+                             Dialog="OpenFolderDialogMultiselect"
+                             FileName="dir1;dir3"
+                             TestType="TypeFileNameAndOpen"/>
+        </ActivationStep.UIHandlers>
+      </ActivationStep>
+    </TestLogStep>
+  </Steps>
+</AppMonitorConfig>

--- a/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/scripts/OpenFolderDialogMultiSelect_config.xml
+++ b/src/Test/AppModel/FeatureTests/CommonDialogs/OpenFolderDialogTests/scripts/OpenFolderDialogMultiSelect_config.xml
@@ -1,7 +1,7 @@
 <AppMonitorConfig>
   <Using Namespace="Microsoft.Windows.Test.Client.AppSec.BVT" Assembly="CommonFileDialogHandler"/>
   <Steps>
-    <TestLogStep Name="OpenFolderDialog: AllCustomPlaces - Verify specifying all custom places will still allow the dialog to display">
+    <TestLogStep Name="OpenFolderDialog: MultiSelect - Verify specifying multiselect allow the dialog to return multiple paths">
       <ActivationStep Method="launch" Scheme="Local" FileName="OpenFolderDialogTests.exe">
         <ActivationStep.UIHandlers>
           <CommonFileDialogHandler WindowTitle="property:Microsoft.Test.Loaders.ApplicationDeploymentHelper.OpenFolderDialogTitle, TestRuntime" 

--- a/src/Test/AppModel/FeatureTests/Data/AppModelData.csproj
+++ b/src/Test/AppModel/FeatureTests/Data/AppModelData.csproj
@@ -7,6 +7,10 @@
       <Link>CommonDialogs\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="..\CommonDialogs\OpenFolderDialogTests\scripts\*.xml">
+      <Link>OpenFolderDialogTests\%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Addin\*.xaml">
       <Link>Data\AddIn\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/src/Test/AppModel/FeatureTests/Navigation/UIHandler/CommonFileDialogHandler.cs
+++ b/src/Test/AppModel/FeatureTests/Navigation/UIHandler/CommonFileDialogHandler.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Windows.Test.Client.AppSec.BVT
         private static String s_SAVEBUTTONNAME = "Save";
         private static String s_OPENBUTTONNAME = "Open";
         private static String s_CLOSEBUTTONNAME = "Close";
+        private static String s_OPENFOLDERBUTTONNAME = "Select Folder";
+
         // Modal MessageBox button names
         private static String s_YESBUTTONNAME = "Yes";
         private static String s_OKBUTTONNAME = "OK";
@@ -51,6 +53,7 @@ namespace Microsoft.Windows.Test.Client.AppSec.BVT
 
         private static string s_openTextBoxId = "1148";
         private static string s_saveTextBoxId = "1148";
+        private static string s_folderTextBoxId = "1152";
         private static string s_vistaSaveTextBoxId = "1001";
 
         #region const class names
@@ -301,6 +304,10 @@ namespace Microsoft.Windows.Test.Client.AppSec.BVT
 #endif
                 }
             }
+            else if (Dialog.ToLowerInvariant().Contains("folder"))
+            {
+                return TypeFileNameAndPressButton(param, s_OPENFOLDERBUTTONNAME, s_OK_AUTOID, s_folderTextBoxId, hWnd);
+            }
             else if (Dialog.ToLowerInvariant().Contains("open"))
             {
                 return TypeFileNameAndPressButton(param, s_OPENBUTTONNAME, s_OK_AUTOID, s_openTextBoxId, hWnd);
@@ -336,6 +343,10 @@ namespace Microsoft.Windows.Test.Client.AppSec.BVT
                     return TypeFileNameAndPressButton(param, s_CANCELBUTTONNAME, s_CANCEL_AUTOID, s_vistaSaveTextBoxId, hWnd);
 #endif
                 }
+            }
+            else if (Dialog.ToLowerInvariant().Contains("folder"))
+            {
+                return TypeFileNameAndPressButton(param, s_CANCELBUTTONNAME, s_CANCEL_AUTOID, s_folderTextBoxId, hWnd);
             }
             else if (Dialog.ToLowerInvariant().Contains("open"))
             {
@@ -431,6 +442,10 @@ namespace Microsoft.Windows.Test.Client.AppSec.BVT
                     return TypeFileNameAndPressButton(param, s_SAVEBUTTONNAME, s_OK_AUTOID, s_vistaSaveTextBoxId, hWnd);
 #endif
                 }
+            }
+            else if (Dialog.ToLowerInvariant().Contains("folder"))
+            {
+                textBoxId = s_folderTextBoxId;
             }
             else if (Dialog.ToLowerInvariant().Contains("open"))
             {

--- a/src/Test/AppModel/FeatureTests/Navigation/UIHandler/CommonFileDialogHandler.cs
+++ b/src/Test/AppModel/FeatureTests/Navigation/UIHandler/CommonFileDialogHandler.cs
@@ -298,7 +298,7 @@ namespace Microsoft.Windows.Test.Client.AppSec.BVT
                 {
                     //conditional for running against WPF4 vs 3.  V3 should use "saveTextBoxId".  V4 on Vista needs "vistaSaveTextBoxId".
 #if TESTBUILD_CLR20
-                    return TypeFileNameAndPressButton(param, SAVEBUTTONNAME, OK_AUTOID, saveTextBoxId, hWnd);
+                    return TypeFileNameAndPressButton(param, s_SAVEBUTTONNAME, s_OK_AUTOID, s_saveTextBoxId, hWnd);
 #else
                     return TypeFileNameAndPressButton(param, s_SAVEBUTTONNAME, s_OK_AUTOID, s_vistaSaveTextBoxId, hWnd);
 #endif
@@ -338,7 +338,7 @@ namespace Microsoft.Windows.Test.Client.AppSec.BVT
                 {
                     //conditional for running against WPF4 vs 3.  V3 should use "saveTextBoxId".  V4 on Vista needs "vistaSaveTextBoxId".
 #if TESTBUILD_CLR20
-                    return TypeFileNameAndPressButton(param, CANCELBUTTONNAME, CANCEL_AUTOID, saveTextBoxId, hWnd);
+                    return TypeFileNameAndPressButton(param, s_CANCELBUTTONNAME, s_CANCEL_AUTOID, s_saveTextBoxId, hWnd);
 #else
                     return TypeFileNameAndPressButton(param, s_CANCELBUTTONNAME, s_CANCEL_AUTOID, s_vistaSaveTextBoxId, hWnd);
 #endif
@@ -437,7 +437,7 @@ namespace Microsoft.Windows.Test.Client.AppSec.BVT
                 else //we're on Vista or newer, should see Vista-style dialog
                 {
 #if TESTBUILD_CLR20
-                    return TypeFileNameAndPressButton(param, SAVEBUTTONNAME, OK_AUTOID, saveTextBoxId, hWnd);
+                    return TypeFileNameAndPressButton(param, s_SAVEBUTTONNAME, s_OK_AUTOID, s_saveTextBoxId, hWnd);
 #else
                     return TypeFileNameAndPressButton(param, s_SAVEBUTTONNAME, s_OK_AUTOID, s_vistaSaveTextBoxId, hWnd);
 #endif

--- a/src/Test/AppModel/FeatureTests/XTCs/CommonDialogs.xtc
+++ b/src/Test/AppModel/FeatureTests/XTCs/CommonDialogs.xtc
@@ -717,7 +717,7 @@
       Type="Functional"
       Area="AppModel"
       SubArea="CommonDialogs"
-      Description="OpenFolderDialog: CustomPlaces - Verify specifying a custom place, and clicking on it, opens the file in the custom place" >
+      Description="OpenFolderDialog: CustomPlaces - Verify specifying a custom place, and clicking on it, opens the folder in the custom place" >
    <Driver Executable="sti.exe" />
    <DriverParameters Class="Microsoft.Test.TestTypes.ApplicationMonitorTest"
                  Assembly="TestRuntime"

--- a/src/Test/AppModel/FeatureTests/XTCs/CommonDialogs.xtc
+++ b/src/Test/AppModel/FeatureTests/XTCs/CommonDialogs.xtc
@@ -674,5 +674,115 @@
    </Versions>
 </TEST>
 
+<TEST Name="FolderDialog_AllCustomPlaces"
+      Priority="1"
+      Type="Functional"
+      Area="AppModel"
+      SubArea="CommonDialogs"
+      Description="OpenFolderDialog: AllCustomPlaces - Verify specifying all custom places will still allow the dialog to display" >
+   <Driver Executable="sti.exe" />
+   <DriverParameters Class="Microsoft.Test.TestTypes.ApplicationMonitorTest"
+                 Assembly="TestRuntime"
+                 Method="RunConfigurationFile"
+                 TestStartupUri="OpenFolderDialogAllCustomPlacesTest"
+                 MethodParams="OpenFolderDialogAllCustomPlaces_config.xml"
+                 SecurityLevel="FullTrust"/>
+   <SupportFiles>
+      <SupportFile Source="FeatureTests\AppModel\OpenFolderDialogTests\*" />
+      <SupportFile Source="FeatureTests\AppModel\Navigation\CommonFileDialogHandler.dll" />
+   </SupportFiles>
+</TEST>
+
+<TEST Name="FolderDialog_CancelTest"
+      Priority="1"
+      Type="Functional"
+      Area="AppModel"
+      SubArea="CommonDialogs"
+      Description="OpenFolderDialog: CancelTest - Show open folder dialog, then cancel the dialog without opening" >
+   <Driver Executable="sti.exe" />
+   <DriverParameters Class="Microsoft.Test.TestTypes.ApplicationMonitorTest"
+                 Assembly="TestRuntime"
+                 Method="RunConfigurationFile"
+                 TestStartupUri="OpenFolderDialogCancelTest"
+                 MethodParams="OpenFolderDialogCancelTest_config.xml"
+                 SecurityLevel="FullTrust"/>
+   <SupportFiles>
+      <SupportFile Source="FeatureTests\AppModel\OpenFolderDialogTests\*" />
+      <SupportFile Source="FeatureTests\AppModel\Navigation\CommonFileDialogHandler.dll" />
+   </SupportFiles>
+</TEST>
+
+<TEST Name="FolderDialog_CustomPlaceTest"
+      Priority="1"
+      Type="Functional"
+      Area="AppModel"
+      SubArea="CommonDialogs"
+      Description="OpenFolderDialog: CustomPlaces - Verify specifying a custom place, and clicking on it, opens the file in the custom place" >
+   <Driver Executable="sti.exe" />
+   <DriverParameters Class="Microsoft.Test.TestTypes.ApplicationMonitorTest"
+                 Assembly="TestRuntime"
+                 Method="RunConfigurationFile"
+                 TestStartupUri="OpenFolderDialogCustomPlaceTest"
+                 MethodParams="OpenFolderDialogCustomPlaceTest_config.xml"
+                 SecurityLevel="FullTrust"/>
+   <SupportFiles>
+      <SupportFile Source="FeatureTests\AppModel\OpenFolderDialogTests\*" />
+      <SupportFile Source="FeatureTests\AppModel\Navigation\CommonFileDialogHandler.dll" />
+   </SupportFiles>
+</TEST>
+
+<TEST Name="FolderDialog_MultiSelect"
+      Priority="1"
+      Type="Functional"
+      Area="AppModel"
+      SubArea="CommonDialogs"
+      Description="OpenFolderDialog: MultiSelect - Verify specifying multiselect allow the dialog to return multiple paths" >
+   <Driver Executable="sti.exe" />
+   <DriverParameters Class="Microsoft.Test.TestTypes.ApplicationMonitorTest"
+                 Assembly="TestRuntime"
+                 Method="RunConfigurationFile"
+                 TestStartupUri="OpenFolderDialogMultiSelect"
+                 MethodParams="OpenFolderDialogMultiSelect_config.xml"
+                 SecurityLevel="FullTrust"/>
+   <SupportFiles>
+      <SupportFile Source="FeatureTests\AppModel\OpenFolderDialogTests\*" />
+      <SupportFile Source="FeatureTests\AppModel\Navigation\CommonFileDialogHandler.dll" />
+   </SupportFiles>
+</TEST>
+
+<TEST Name="FolderDialog_OpenFolderIsThreadModal"
+      Priority="1"
+      Type="Functional"
+      Area="AppModel"
+      SubArea="CommonDialogs"
+      Description="FolderDialog - OpenFolderIsThreadModal - Verify ComponentDispatcher.IsThreadModal is true when the OpenFileDialog is shown" >
+   <Driver Executable="sti.exe" />
+   <DriverParameters Class="Microsoft.Test.TestTypes.ApplicationMonitorTest"
+                 Assembly="TestRuntime"
+                 Method="RunApplication"
+                 SecurityLevel="FullTrust"
+                 MethodParams="FolderDialogTests.exe /test:openfolderisthreadmodal" />
+   <SupportFiles>
+      <SupportFile Source="FeatureTests\AppModel\FolderDialogTests\*" />
+   </SupportFiles>
+</TEST>
+
+<TEST Name="FolderDialog_OpenFolderDialogCustomPlaceCases"
+      Priority="1"
+      Type="Functional"
+      Area="AppModel"
+      SubArea="CommonDialogs"
+      Description="Folder Dialog Test: CustomPlace cases" >
+   <Driver Executable="sti.exe" />
+   <DriverParameters Class="Microsoft.Test.TestTypes.ApplicationMonitorTest"
+                 Assembly="TestRuntime"
+                 Method="RunApplication"
+                 SecurityLevel="FullTrust"
+                 MethodParams="FolderDialogTests.exe /test:openfolderdialogcustomplacecases" />
+   <SupportFiles>
+      <SupportFile Source="FeatureTests\AppModel\FolderDialogTests\*" />
+   </SupportFiles>
+</TEST>
+
 </XTC>
 

--- a/src/Test/Common/Code/Microsoft/Test/Loaders/ApplicationDeploymentHelper.cs
+++ b/src/Test/Common/Code/Microsoft/Test/Loaders/ApplicationDeploymentHelper.cs
@@ -498,15 +498,24 @@ namespace Microsoft.Test.Loaders
         }
 
         /// <summary>
-        /// Returns the correct title for the ComDlg32.dll Open File Dialog
+        /// Returns the correct title for the ComDlg32.dll Open Folder Dialog
         /// </summary>
         public static string OpenFolderDialogTitle
         {
             get
             {
-                if (openFolderDialogTitle == null)
+                if (saveFileDialogTitle == null)
                 {
-                    openFolderDialogTitle = "Select Folder";
+                    try
+                    {
+                        // 439 = String resource ID for Select Folder in ComDlg32
+                        saveFileDialogTitle = getComDlgStringResource(439).Replace("(&S)", "").Replace("&", "");
+                    }
+                    // Fall back to English.  This is good because the #1 reason we have to fall back is lack of LOC resources
+                    catch
+                    {
+                        saveFileDialogTitle = "Select Folder";
+                    }
                 }
                 return openFolderDialogTitle;
             }

--- a/src/Test/Common/Code/Microsoft/Test/Loaders/ApplicationDeploymentHelper.cs
+++ b/src/Test/Common/Code/Microsoft/Test/Loaders/ApplicationDeploymentHelper.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Test.Loaders
         private static string cancelPageUIButtonName = null;
         private static string openFileDialogTitle = null;
         private static string saveFileDialogTitle = null;
+        private static string openFolderDialogTitle = null;
         #endregion
 
         #region Private Methods
@@ -495,6 +496,22 @@ namespace Microsoft.Test.Loaders
                 return saveFileDialogTitle;
             }
         }
+
+        /// <summary>
+        /// Returns the correct title for the ComDlg32.dll Open File Dialog
+        /// </summary>
+        public static string OpenFolderDialogTitle
+        {
+            get
+            {
+                if (openFolderDialogTitle == null)
+                {
+                    openFolderDialogTitle = "Select Folder";
+                }
+                return openFolderDialogTitle;
+            }
+        }
+
 
         // Methods for extracting the localized text for the Browser-app exception page
         /// <summary>


### PR DESCRIPTION
Fixes Issue <!-- Issue Number --> #129 

## Description
This PR adds a few tests for the upcoming OpenFolderDialog API. 
It mostly derives from file dialog tests. Apart from that added a test for Multiselect functionality.

There are two ways in which common dialog tests are executed - one RunApplication mode, which runs an application and the second is RunConfigurationFile, which allows the test infra to interact with the dialog. I have created separate projects for each of them.

Added a total of 6 tests, out of which 5 are passing. 1 failure is similar to that in the OpenFileDialog test ( failing test is a copy of a test for OpenFileDialog ). 

Here are the guidelines/process for adding tests for new public APIs : [test-addition-guidelines](https://github.com/dotnet/wpf-test/blob/main/docs/test-addition-guidelines.md)

PS : As of now, I have not added the projects in root sln ( Microsoft.Dotnet.Wpf.Test.sln ) because it will break the build.

### Steps for building this PR

Take the `FolderDialogTests` and `OpenFolderDialogTests` project nodes from `AppModel.sln` and add them to `Microsoft.Dotnet.Wpf.Test.sln`. Now follow the steps mentioned in the above test addition guideline link.
 
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Allows developers to run tests on OpenFolderDialog
<!-- What is the impact to customers of not taking this fix? -->

## Regression
--
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Built and ran the tests
<!-- What kind of testing has been done with the fix. -->

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf-test/pull/130)