### PR TITLE
Fixing DRT Window Functionality

### DIFF
--- a/src/Test/AppModel/DRT/Window/WindowFunctionality/DrtWindowFunctionality.cs
+++ b/src/Test/AppModel/DRT/Window/WindowFunctionality/DrtWindowFunctionality.cs
@@ -525,6 +525,9 @@ namespace DRT
         private void OnSizeChanged(object sender, EventArgs args)
         {
             _fSizeChanged = true;
+            // This is to bring back focus to the DRT window as after performing these changes 
+            // the window was losing its focus.
+            _win.Focus();
         }
 
         private void OnLocationChanged(object sender, EventArgs args)


### PR DESCRIPTION
Fixing DRT Window Functionality.

### Description
The test was failing because the Drt window was losing focus after calling OnSizeChanged()

### Fix
Added focus to the Drt window 