### PR TITLE
Fixing Drt WindowAutoSize

### DIFF
--- a/src/Test/AppModel/DRT/Window/WindowAutoSize/DrtWindowAutoSize.cs
+++ b/src/Test/AppModel/DRT/Window/WindowAutoSize/DrtWindowAutoSize.cs
@@ -241,7 +241,10 @@ namespace DRT
         private void ResizeWindow()
         {
             RECT rect = new RECT();
-
+            
+            // This is to bring back focus to the DRT window as after performing these changes 
+            // the window was losing its focus.
+            _win.Focus();
             IntPtr hwnd = GetForegroundWindow();
 
             if (hwnd != _handle)


### PR DESCRIPTION
Fixing DRT WindowAutoSize

### Description
DRT window was losing focus.
Error: Foreground window did not match DRT window.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf-test/pull/165)