### PR TITLE
Fixing DRTs failing due to WindowStyle = 'Hidden'

### DIFF
--- a/src/Test/Common/Code/Microsoft/Test/Drt/DrtRunner.cs
+++ b/src/Test/Common/Code/Microsoft/Test/Drt/DrtRunner.cs
@@ -66,7 +66,8 @@ namespace Microsoft.Test.Drt
             {
                 ProcessStartInfo processInfo = new ProcessStartInfo(exeName, args);
                 processInfo.UseShellExecute = false;
-                processInfo.WindowStyle = ProcessWindowStyle.Hidden;
+                // Setting window style to default (normal)
+                //processInfo.WindowStyle = ProcessWindowStyle.Hidden;
                 processInfo.RedirectStandardOutput = true;
                 processInfo.CreateNoWindow = true;
 


### PR DESCRIPTION
Fixing DRTs failing due to WindowStyle = 'Hidden'
DRT fixed:

1.  DrtStickyNoteControl
2. DrtWindowAutoSize
3. DrtWindowFunctionality
4. DrtWindowResizeGripFlowDirection
5. DrtWindowSroll
6. DrtInput
7. DrtInputMethod
8. DrtCommanding
9. DrtFixedEdit
10.  DrtInkCanvas


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf-test/pull/181)