### PR TITLE
Fixing the path for visual studio installation.

### DIFF
--- a/src/Test/Infra/QualityVault/QualityVaultUtilities/Execution/DriverLauncher.cs
+++ b/src/Test/Infra/QualityVault/QualityVaultUtilities/Execution/DriverLauncher.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Test.Execution
             string instructions3 = "Close this console when you are done.";
             if (settings.DebugTests && !settings.WaitForDebugger)
             {
-            	string programFiles = System.Environment.Is64BitOperatingSystem ? "%ProgramFiles(x86)%" : "%ProgramFiles%";
+            	string programFiles = !System.Environment.Is64BitOperatingSystem ? "%ProgramFiles(x86)%" : "%ProgramFiles%";
 				string vs1 = programFiles + @"\Microsoft Visual Studio\";
 				string vs2a = @"..\IDE\devenv.exe";						// for VS2015-
 				string vs2b = @"\Enterprise\Common7\IDE\devenv.exe";	// for VS2017+


### PR DESCRIPTION
## Description

If we use the /DebugTests argument to debug tests, we are presented with various options. If we choose vs.cmd, it fails to launch Visual Studio due to an incorrect installation path being added to vs.cmd.

This PR fixes the installation path based on the system infrastructure (x86 or x64).

## Customer Impact

To debug, it will be necessary to manually correct the installation path of VS in VS.cmd.

## Regression

NA

## Testing

NA

## Risk

none


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf-test/pull/190)