### PR TITLE
Remove unused ReleaseAnnouncement issue/PR automation

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -625,18 +625,6 @@
     },
     {
       "taskType": "trigger",
-      "capabilityId": "ReleaseAnnouncement",
-      "subCapability": "ReleaseAnnouncement",
-      "version": "1.0",
-      "config": {
-        "taskName": "Release announcement",
-        "prReply": "The fix is included in ${pkgName} ${version}.",
-        "issueReply": "Fixed in ${pkgName} ${version}."
-      },
-      "disabled": true
-    },
-    {
-      "taskType": "trigger",
       "capabilityId": "InPrLabel",
       "subCapability": "InPrLabel",
       "version": "1.0",


### PR DESCRIPTION
This automation capability has been deprecated. It was already disabled in this configuration, but this removes it from the configuration.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf-test/pull/218)